### PR TITLE
The Promise in the first example defers execution of 'doFirst'

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ let doSecond = () => {
     console.log('Do second.');
 }
 
-let doFirst = new Promise((resolve, reject) => {
+let doFirst = () => new Promise((resolve, reject) => {
     setTimeout(() => {
         console.log('Do first.');
         
@@ -432,7 +432,7 @@ let doFirst = new Promise((resolve, reject) => {
     }, 500);
 });
   
-doFirst.then(doSecond);
+doFirst().then(doSecond);
 ```
 
 An example below using `XMLHttpRequest`, for demonstrative purposes only ([Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) would be the proper modern API to use).


### PR DESCRIPTION
I stumbled on this many times while using Promises: I always forget that when you define a promise, the Promise argument function get executed immediately. So when you write 
```js
doFirst.then(doSecond)
```
what you plan to _do first_, really already happened.
If you think that other could be misleaded as I am, I suggest this change. 
In any case, thank you for the excellent work.